### PR TITLE
Potential fix for code scanning alert no. 1: Flask app is run in debug mode

### DIFF
--- a/src/data/app.py
+++ b/src/data/app.py
@@ -14,4 +14,6 @@ def get_dados():
     # return text
 
 if __name__ == '__main__':
-    app.run(debug=True)
+    import os
+    debug_mode = os.getenv('FLASK_DEBUG', '0') == '1'
+    app.run(debug=debug_mode)


### PR DESCRIPTION
Potential fix for [https://github.com/ines-salgado/real_estate/security/code-scanning/1](https://github.com/ines-salgado/real_estate/security/code-scanning/1)

To fix the issue, we will modify the `app.run()` call to ensure that debug mode is not enabled by default. Instead, we will use an environment variable to control whether debug mode is enabled. This approach allows developers to enable debug mode during development without risking it being enabled in production. Specifically:
1. Import the `os` module to access environment variables.
2. Replace `debug=True` with a conditional check that reads the `FLASK_DEBUG` environment variable. If the variable is set to `'1'`, debug mode will be enabled; otherwise, it will be disabled.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
